### PR TITLE
DI 444 - Index collections to support nested browsing with pivot facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -59,7 +59,18 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5
+    # config.add_facet_field "member_of_collections_ssim", limit: 5
+
+    # Configure fields used in pivot facet
+    # Collection: single = true, to allow max. 1 parent collection to be selected
+    config.add_facet_field "member_of_parent_collections_ssim", label: "Collection", single: true, show: false
+
+    # Subcollection: single = false (default) to allow multiple sub-collections to be applied as filters
+    config.add_facet_field "member_of_subcollections_ssim", label: "Subcollection", show: false
+
+    # Set collapse = false to show all collections / subcollections
+    # Add collapsing = true after upgrade to BL v7+ to add expand/collapse options for each outer facet
+    config.add_facet_field "Collections", pivot: ["member_of_parent_collections_ssim", "member_of_subcollections_ssim"], collapse: false
     config.add_facet_field "resource_type_sim", limit: 5
     config.add_facet_field "date_created_year_ssim", limit: 5, label: "Date Created"
     config.add_facet_field "creator_sim", limit: 5

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -59,18 +59,20 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    # config.add_facet_field "member_of_collections_ssim", limit: 5
-
-    # Configure fields used in pivot facet
-    # Collection: single = true, to allow max. 1 parent collection to be selected
-    config.add_facet_field "member_of_parent_collections_ssim", label: "Collection", single: true, show: false
-
-    # Subcollection: single = false (default) to allow multiple sub-collections to be applied as filters
-    config.add_facet_field "member_of_subcollections_ssim", label: "Subcollection", show: false
-
-    # Set collapse = false to show all collections / subcollections
-    # Add collapsing = true after upgrade to BL v7+ to add expand/collapse options for each outer facet
-    config.add_facet_field "Collections", pivot: ["member_of_parent_collections_ssim", "member_of_subcollections_ssim"], collapse: false
+ 
+    # Solr fields added to index to support pivot facet on top-level collections, subcollections:
+    # member_of_parent_collections_ssim, member_of_subcollections_ssim
+    #
+    # After upgrading to Hyrax v4 w/ Blacklight 7, add pivot facet w/ collapsing facets:
+    # config.add_facet_field "Collections", pivot: ["member_of_parent_collections_ssim", "member_of_subcollections_ssim"], collapse: false, collapsing: true
+    # 
+    # For pivot facet to be applied as filters, individual facets may need to be added but not shown. 
+    # Test after upgrade.  See https://github.com/projectblacklight/blacklight/issues/2463.
+    # config.add_facet_field "member_of_subcollections_ssim", label: "Subcollection", show: false
+    # config.add_facet_field "member_of_parent_collections_ssim", label: "Collection", single: true, show: false
+    # 
+    # Until upgrade to Hyrax v4, configure Collections facet to show top-level collections only:
+    config.add_facet_field "member_of_parent_collections_ssim", limit: 5, label: "Collections"
     config.add_facet_field "resource_type_sim", limit: 5
     config.add_facet_field "date_created_year_ssim", limit: 5, label: "Date Created"
     config.add_facet_field "creator_sim", limit: 5

--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -9,13 +9,17 @@ class EtdIndexer < Hyrax::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
+  # Index an object's top-level parent collection(s)
+  include ParentCollectionBehavior
+
   # Use date parsing helper in HyraxHelper
   include HyraxHelper
 
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc['date_created_year_ssim'] = object.date_created.map{ |value| date_created_year(value) }
+      solr_doc['date_created_year_ssim'] = object.date_created.map { |value| date_created_year(value) }
+      solr_doc = index_parent_collections(solr_doc)
     end
   end
 end

--- a/app/indexers/parent_collection_behavior.rb
+++ b/app/indexers/parent_collection_behavior.rb
@@ -1,0 +1,29 @@
+# Functions to index work parent collection(s)
+module ParentCollectionBehavior
+    extend ActiveSupport::Concern
+    
+    # Recurse through object's member_of_collections attribute to identify
+    # which collections are top-level collections (i.e., have no parents)
+    def parent_collection_ids(object)
+      return [] if object.nil?
+      parents = object.member_of_collections
+      ids = []
+      parents.each do |parent|
+        if parent.member_of_collections.empty?
+            ids << parent.id 
+        else
+            ids += parent_collection_ids(parent)
+        end
+      end
+      ids.uniq
+    end
+  
+    def index_parent_collections(doc)
+      parent_collection_ids = parent_collection_ids(object)
+      subcollection_ids = doc['member_of_collection_ids_ssim'] - parent_collection_ids
+
+      doc['member_of_parent_collections_ssim'] = parent_collection_ids.map{|id| SolrDocument.find(id).title.first}
+      doc['member_of_subcollections_ssim'] = subcollection_ids.map{|id| SolrDocument.find(id).title.first}
+      doc 
+    end
+  end

--- a/app/indexers/research_work_indexer.rb
+++ b/app/indexers/research_work_indexer.rb
@@ -9,13 +9,17 @@ class ResearchWorkIndexer < Hyrax::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
+  # Index an object's top-level parent collection(s)
+  include ParentCollectionBehavior
+
   # Use date parsing helper in HyraxHelper
   include HyraxHelper
 
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc['date_created_year_ssim'] = object.date_created.map{ |value| date_created_year(value) }
+      solr_doc['date_created_year_ssim'] = object.date_created.map { |value| date_created_year(value) }
+      solr_doc = index_parent_collections(solr_doc)
     end
   end
 end

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -22,7 +22,6 @@ class WorkIndexer < Hyrax::WorkIndexer
       solr_doc = index_parent_collections(solr_doc)
     end
   end
-
 end
 
 

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -9,6 +9,9 @@ class WorkIndexer < Hyrax::WorkIndexer
   # this behavior
   include Hyrax::IndexesLinkedMetadata
 
+  # Index an object's top-level parent collection(s)
+  include ParentCollectionBehavior
+
   # Use date parsing helper in HyraxHelper
   include HyraxHelper
 
@@ -16,8 +19,10 @@ class WorkIndexer < Hyrax::WorkIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc['date_created_year_ssim'] = object.date_created.map { |value| date_created_year(value) }
+      solr_doc = index_parent_collections(solr_doc)
     end
   end
+
 end
 
 


### PR DESCRIPTION
Add solr fields for a pivot facet on top-level collections, sub-collections. 

Update catalogue controller to show only top-level collection facet for now, until upgrade to Hyrax v4 / Blacklight 7 adds support for expanding / collapsing pivot facets. 