### PR TITLE
DI-459 Adjust collection search result: move counts boxes under thumbnail

### DIFF
--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -5,25 +5,11 @@
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
         <div class="row">
-          <dt class="col-4 text-right" data-solr-field-name="<%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
-          <dd class="col-8"><%= doc_presenter.field_value field %></dd>
+          <dt class="col-3 text-right" data-solr-field-name="<%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
+          <dd class="col-9"><%= doc_presenter.field_value field %></dd>
         </div>
       <% end %>
     <% end %>
     </dl>
   </div>
 </div>
-<% if document.collection? %>
-<% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
-<div class="col-md-12 col-lg-3">
-  <div class="collection-counts-wrapper">
-    <div class="collection-counts-item">
-      <span><%= collection_presenter.total_viewable_collections %></span>Collections
-    </div>
-    <div class="collection-counts-item">
-      <span><%= collection_presenter.total_viewable_works %></span>Works
-    </div>
-  </div>
-</div>
-<% end %>
-

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,0 +1,13 @@
+<div class="col-md-3 text-center">
+  <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, { suppress_link: true }) %>
+  <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
+  <div class="collection-counts-wrapper m-2 justify-content-center">
+    <div class="collection-counts-item">
+        <span><%= collection_presenter.total_viewable_collections %></span>Collections
+    </div>
+    <div class="collection-counts-item">
+        <span><%= collection_presenter.total_viewable_works %></span>Works
+    </div>
+    </div>
+</div> 
+


### PR DESCRIPTION
Wider column for metadata values in catalog search results forces collection count boxes to wrap -- move under collection thumbnail. 