### PR TITLE
Specs for DI 458 -- configure repository features set in config/features.yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'blacklight_oai_provider'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  # Use FactoryBot to create test objects
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,11 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     execjs (2.9.1)
+    factory_bot (6.4.5)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     faraday (2.7.11)
       base64
       faraday-net_http (>= 2.0, < 3.1)
@@ -1032,6 +1037,7 @@ DEPENDENCIES
   cookies_eu
   devise
   devise-guests (~> 0.6)
+  factory_bot_rails
   fcrepo_wrapper
   hydra-role-management
   hyrax (~> 4.0)

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# A very basic factory for FileSets, based o
+# https://github.com/UNC-Libraries/hy-c/blob/main/spec/factories/file_sets.rb
+
+FactoryBot.define do
+
+  factory :file_set do
+
+    title { ['Generic work'] } 
+
+    transient do
+      # For now fetch user seeded in db; later, replace w/ users factory
+      depositing_user { User.find_by(email: 'staff_user@example.com') }
+
+      # Set generic work PDF as default content
+      content { File.open("#{RSpec.configuration.fixture_path}/generic_work.pdf") }
+    end
+
+    # Use transient user to set file_set attributes
+    after(:build) do |file_set, context|
+      file_set.apply_depositor_metadata(context.depositing_user.user_key)
+    end
+
+    # Upload file, if file content defined
+    after(:create) do |file_set, context|
+      Hydra::Works::UploadFileToFileSet.call(file_set, context.content) if context.content
+    end
+
+    # Set file visibility to Public
+    trait :public_visibility do
+      read_groups { ['public'] }
+    end
+
+    # Set file visibility to Private
+    trait :private_visibility do 
+      # Default if no read_groups defined
+    end
+
+    # shortcuts to create public, private files
+    factory :public_file, traits: [:public_visibility]
+    factory :private_file, traits: [:private_visibility]
+  end
+
+end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# A very gentle start with FactoryBot, based on
+# https://github.com/UNC-Libraries/hy-c/blob/main/spec/factories/general.rb
+
+FactoryBot.define do
+
+  factory :work do
+    # Required metadata
+    title { ['Title for a generic work ' + Time.new.strftime("%Y-%m-%d %H:%M:%S")] }
+    resource_type { ['Report'] }
+
+    # Define transient attributes: these are only available in the factory block
+    # & can be used to define / fetch / set additional work attributes
+    transient do 
+      # For now, fetch user and admin set seeded in db/seeds.rb, although 
+      # these could/should be replaced w/ factories -- see file ref'd above
+      depositing_user { User.find_by(email: 'staff_user@example.com') }
+      default_admin_set { Hyrax::AdminSetCreateService.find_or_create_default_admin_set }
+    end
+
+    # Use transient user & admin_set objects to set Work attributes
+    # See hook invocation order at https://thoughtbot.github.io/factory_bot/ref/build-strategies.html
+    after(:build) do |work, context|
+      work.apply_depositor_metadata(context.depositing_user.user_key)
+      work.admin_set_id = context.default_admin_set.id.to_s
+    end
+
+    # Use traits to create works with different attributes
+    trait :public do
+      visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    end
+
+    trait :private do 
+      # default visibility is private
+    end
+
+    # Create a public work with a public file
+    factory :public_work_with_public_file, traits: [:public] do
+      before(:create) do |work, context|
+        work.ordered_members << create(:public_file)
+      end
+    end
+
+    # Create a public work with a private file 
+    factory :public_work_with_private_file, traits: [:public] do
+      before(:create) do |work, context|
+        work.ordered_members << create(:private_file)
+      end
+    end
+  end
+
+end

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -109,9 +109,7 @@ RSpec.feature 'Create an Etd', js: true do
       # Set work visibility
       choose('etd_visibility_open')
 
-      # Accept deposit agreement
-      check('agreement')
-
+      # Save Etd. Deposit agreement is configured for passive acceptance.
       click_on("Save")
 
       # Expect work files to be processing in the background

--- a/spec/features/create_research_work_spec.rb
+++ b/spec/features/create_research_work_spec.rb
@@ -87,9 +87,7 @@ RSpec.feature 'Create a ResearchWork', js: true do
       # Set work visibility
       choose('research_work_visibility_open')
 
-      # Accept deposit agreement
-      check('agreement')
-
+      # Save work. Deposit agreement is configured for passive acceptance.
       click_on("Save")
 
       # Expect work files to be processing in the background

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'View a work', js: true do
+  let(:work) { FactoryBot.create(:public_work_with_private_file) }
+
+  context 'when not logged in' do
+    scenario 'private file is NOT displayed' do
+      # View work
+      visit '/concern/works/' + work.id
+      expect(page).not_to have_css('table.related-files')
+      expect(page).to have_content 'There are no publicly available items in this Work.'
+    end
+  end
+
+  context 'as a logged-in user' do
+    # basic user (login only, no privileges) seeded in db
+    let(:basic_user) { User.find_by(email: 'basic_user@example.com') }
+
+    before { login_as basic_user }
+
+    scenario 'private file is NOT displayed' do
+      # View work
+      visit '/concern/works/' + work.id
+      expect(page).not_to have_css('table.related-files')
+      expect(page).to have_content 'There are no publicly available items in this Work.'
+    end
+  end
+
+  context 'as a Library staff user' do
+    # staff user seeded in db
+    let(:staff_user) { User.find_by(email: 'staff_user@example.com') }
+
+    before { login_as staff_user }
+
+    scenario 'private file is displayed' do
+      # View work
+      visit '/concern/works/' + work.id
+      expect(page).to have_css('table.related-files')
+    end
+  end
+
+
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,6 +72,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # Use FactoryBot to create test objects
+  config.include FactoryBot::Syntax::Methods
+
   # Set up environment before running tests
   config.before(:suite) do
     # Reset Fedora and Solr

--- a/spec/support/create_and_save_work_spec.rb
+++ b/spec/support/create_and_save_work_spec.rb
@@ -46,17 +46,15 @@ RSpec.shared_examples 'Create and save work' do
     select language, from: 'Language'
     fill_in('Identifier', with: identifier)
 
-    # Set work visibility Public
+    # Set work visibility Public 
     choose('work_visibility_open')
-
-    # Accept deposit agreement 
-    check('agreement')
 
     # Uncomment to help debug flaky tests (visible elements not found, not clickable, etc.)
     # puts "Required metadata: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').requiredFields.areComplete})}"
     # puts "Required files: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').uploads.hasFiles})}"
     # puts "Agreement: #{page.evaluate_script(%{$('#form-progress').data('save_work_control').depositAgreement.isAccepted})}"
 
+    # Save work. Deposit agreement is configured for passive acceptance.
     click_on("Save")
 
     # Expect work files to be processing in the background


### PR DESCRIPTION
Features enabled in config
* passive deposit agreement acceptance
* information about a work's private files only displayed to authorized users

First pass at using FactoryBot & factories for works, file sets. 